### PR TITLE
[rtl] Fix RTL specific variables not overridden in Sass version

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -57,6 +57,7 @@ module.exports = function(grunt) {
     'clean:sass',
     'string-replace:less2sass',
     'string-replace:less2sass_variables',
+    'string-replace:less2sass_variables_override',
     'string-replace:sass_dist',
     'string-replace:less_dist',
     'test-sass'

--- a/dist/sass/tetra-ui-rtl.scss
+++ b/dist/sass/tetra-ui-rtl.scss
@@ -172,14 +172,14 @@ $gridGutterWidth:	20px !default;
 // Overriding the variables declared in variables.less
 // for Right To Left languages
 
-$rtl: true !default;
+$rtl: true;
 
 // Arabic fonts are smaller
 
-$baseFontSize: 15px !default;
-$smallFontSize: $baseFontSize - 1 !default;
-$baseLineHeight: 1.2em !default;
-$font-stack: "Simplified Arabic", "Baghdad", "Arial", sans-serif !default;
+$baseFontSize: 15px;
+$smallFontSize: $baseFontSize - 1;
+$baseLineHeight: 1.2em;
+$font-stack: "Simplified Arabic", "Baghdad", "Arial", sans-serif;
 
 /*! tetra-ui v2.1.15 - 2014 | (MIT Licence) (c) Viadeo/APVO Corp - inspired by Bootstrap (c) Twitter, Inc. (Apache 2 Licence) */
 

--- a/src/sass/foundation/variables_rtl.scss
+++ b/src/sass/foundation/variables_rtl.scss
@@ -1,11 +1,11 @@
 // Overriding the variables declared in variables.less
 // for Right To Left languages
 
-$rtl: true !default;
+$rtl: true;
 
 // Arabic fonts are smaller
 
-$baseFontSize: 15px !default;
-$smallFontSize: $baseFontSize - 1 !default;
-$baseLineHeight: 1.2em !default;
-$font-stack: "Simplified Arabic", "Baghdad", "Arial", sans-serif !default;
+$baseFontSize: 15px;
+$smallFontSize: $baseFontSize - 1;
+$baseLineHeight: 1.2em;
+$font-stack: "Simplified Arabic", "Baghdad", "Arial", sans-serif;

--- a/tasks/options/string-replace.js
+++ b/tasks/options/string-replace.js
@@ -135,6 +135,7 @@ module.exports = {
       }
     ]
   },
+  // Copy variables as default (no override if the variable already exists)
   less2sass_variables: {
     options: {
       replacements: [{
@@ -144,8 +145,20 @@ module.exports = {
       ]
     },
     files: [{
-      '<%= path.sass.src %>/foundation/variables.scss':'<%= path.sass.src %>/foundation/variables.scss',
-      },{
+      '<%= path.sass.src %>/foundation/variables.scss':'<%= path.sass.src %>/foundation/variables.scss'
+      }
+    ]
+  },
+  // Copy variables by overriding the value if exists
+  less2sass_variables_override: {
+    options: {
+      replacements: [{
+          pattern: /(\$.*);/g,
+          replacement: '$1;'
+        }
+      ]
+    },
+    files: [{
       '<%= path.sass.src %>/foundation/variables_rtl.scss':'<%= path.sass.src %>/foundation/variables_rtl.scss'
       }
     ]


### PR DESCRIPTION
Hello Antoine,

The Sass version of Tetra-UI doesn't render the right-to-left (RTL) same as Less version, it's due to the application of a series of "!default" into "variables_rtl.scss" variables (which is the specific override file for RTL), this has no effect to overrides.

For fixing this, I introduce a new Grunt task named "string-replace:less2sass_variables_override" which not add the "!default" token for each copied variable, this "force" the value.

Thanks a lot for the integration.
