### PR TITLE
Rename btn-white to btn-white-alt

### DIFF
--- a/doc/templates/partials/buttons/buttons-basic-example.hbs
+++ b/doc/templates/partials/buttons/buttons-basic-example.hbs
@@ -426,54 +426,53 @@ a class="btn btn-default-alt btn-small">
   </div>
 <p>White buttons (useful on dark background)</p>
 <div class="gu gu-last gu-m-1of1 pll pts bg-gray mbl">
-    <a class="btn btn-white btn-small mbs mrl">Small</a>
-    <a class="btn btn-white mbs mrl">Default</a>
-    <a class="btn btn-white mbs mrl"><span class="vicon vicon-plus btn-icon-before"></span>before</a>
-    <a class="btn btn-white mbs mrl">after<span class="vicon vicon-plus btn-icon-after"></span></a>
-    <a class="btn btn-white btn-loading mbs mrl"><span>Loading</span></a>
-    <a class="btn btn-white btn-disabled mbs mrl">Disable</a>
-    <a class="btn btn-white btn-large mbs mrl">Large</a>
-    <a class="btn btn-white btn-lead mbs mrl">Lead Button</a>
-    <a class="btn btn-white btn-lead-alt mbs mrl">Lead Button alt</a>
-    <a class="btn btn-white btn-fat mbs mrl">Fat Button</a>
+    <a class="btn btn-white-alt btn-small mbs mrl">Small</a>
+    <a class="btn btn-white-alt mbs mrl">Default</a>
+    <a class="btn btn-white-alt mbs mrl"><span class="vicon vicon-plus btn-icon-before"></span>before</a>
+    <a class="btn btn-white-alt mbs mrl">after<span class="vicon vicon-plus btn-icon-after"></span></a>
+    <a class="btn btn-white-alt btn-loading mbs mrl"><span>Loading</span></a>
+    <a class="btn btn-white-alt btn-disabled mbs mrl">Disable</a>
+    <a class="btn btn-white-alt btn-large mbs mrl">Large</a>
+    <a class="btn btn-white-alt btn-lead mbs mrl">Lead Button</a>
+    <a class="btn btn-white-alt btn-lead-alt mbs mrl">Lead Button alt</a>
+    <a class="btn btn-white-alt btn-fat mbs mrl">Fat Button</a>
 
   </div>
 <div class="code-content">
 {{> toggle-code}}
 {{#markdown}}
 ```html
-<!-- Add suffic alt to the button class for alternative buttons -->
-<a class="btn btn-white btn-small">
+<a class="btn btn-white-alt btn-small">
   Small
 </a>
 <!-- The default btn. -->
-<a class="btn btn-white mbs mrl">
+<a class="btn btn-white-alt mbs mrl">
   Default
 </a>
 <!-- Add classname 'btn-icon-before' to prepend the icon -->
-<a class="btn btn-white mbs mrl">
+<a class="btn btn-white-alt mbs mrl">
   <span class="vicon vicon-plus btn-icon-before"></span>
   preprend icon
 </a>
 <!-- Add classname 'btn-icon-after' to append the icon -->
-<a class="btn btn-white mbs mrl">
+<a class="btn btn-white-alt mbs mrl">
   append icon
   <span class="vicon vicon-plus btn-icon-after"></span>
 </a>
 <!-- Add <span> inside the btn-loading to preserve the width of the button -->
-<a class="btn btn-white btn-loading">
+<a class="btn btn-white-alt btn-loading">
   <span>Loading</span>
 </a>
 <!-- Add btn-disabled to the btn class. -->
-<a class="btn btn-white btn-disabled">
+<a class="btn btn-white-alt btn-disabled">
   Disable
 </a>
 <!-- Add btn-large to the btn class. -->
-<a class="btn btn-white btn-large">
+<a class="btn btn-white-alt btn-large">
   Large
 </a>
 <!-- Add btn-lead to the btn class. -->
-<a class="btn btn-white btn-lead">
+<a class="btn btn-white-alt btn-lead">
   Lead Button
 </a>
 

--- a/src/less/components/button.less
+++ b/src/less/components/button.less
@@ -62,7 +62,6 @@
     border-color: @bgColor;
     color: @disabledTextColor;
     opacity: 0.5;
-    color: white;
     > span, .vicon {
       color: @disabledTextColor;
     }
@@ -267,7 +266,7 @@
 .btn-tertiary-alt {
   .alt-tetra-button(tertiary);
 }
-.btn-white{
+.btn-white-alt{
   .alt-tetra-button(wht);
 }
 


### PR DESCRIPTION
To be more consistent with classname conventions for buttons. This PR renames `btn-white` to `btn-white-alt`.

This will also allow us to introduce a `btn-white` button later on.