### PR TITLE
[buttons] Make .btn-icon really round

### DIFF
--- a/src/less/components/button.less
+++ b/src/less/components/button.less
@@ -392,7 +392,7 @@
 }
 
 .btn-icon {
-  padding: 6px 5px;
+  padding: 7px 5px;
   border-radius: 100%;
   .vicon {
     font-size: 10px;

--- a/src/sass/components/button.scss
+++ b/src/sass/components/button.scss
@@ -401,7 +401,7 @@
 }
 
 .btn-icon {
-  padding: 6px 5px;
+  padding: 7px 5px;
   border-radius: 100%;
   .vicon {
     font-size: 10px;


### PR DESCRIPTION
This is a really huge contribution :

before 
<img width="38" alt="screen shot 2015-08-20 at 11 55 17 am" src="https://cloud.githubusercontent.com/assets/180062/9392584/7c3d5996-4732-11e5-8aa0-16c766b7b5bf.png"> 

after 
<img width="38" alt="screen shot 2015-08-20 at 11 55 01 am" src="https://cloud.githubusercontent.com/assets/180062/9392593/81b50946-4732-11e5-800a-6733061e9dbe.png">

ping @bmagnan @duvillierA 